### PR TITLE
replace to mir ndslice.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -16,9 +16,10 @@
         "derelict-al": "~>1.0.1",
         "derelict-ogg": "~>1.0.1",
         "derelict-vorbis": "~>1.0.1",
-        "fswatch": "~>0.2.0"
-    }, 
-	"dflags-ldc":["-disable-linker-strip-dead"],
+        "fswatch": "~>0.2.0",
+        "mir-algorithm":"0.1.1"
+    },
+    "dflags-ldc":["-disable-linker-strip-dead"],
     "copyFiles-windows-x86": [
         "libs/FreeImage/lib/win32/FreeImage.dll",
         "libs/glfw/lib/win32/glfw3.dll",

--- a/dub.json
+++ b/dub.json
@@ -16,7 +16,8 @@
         "derelict-al": "~>1.0.1",
         "derelict-ogg": "~>1.0.1",
         "derelict-vorbis": "~>1.0.1",
-        "fswatch": "~>0.2.0"
-    }, 
-	"dflags-ldc":["-disable-linker-strip-dead"]
+        "fswatch": "~>0.2.0",
+        "mir-algorithm":"0.1.1"
+    },
+    "dflags-ldc":["-disable-linker-strip-dead"]
 }

--- a/source/armos/graphics/bitmap.d
+++ b/source/armos/graphics/bitmap.d
@@ -1,7 +1,7 @@
 module armos.graphics.bitmap;
 import armos.math;
 import armos.graphics;
-import std.experimental.ndslice;
+import mir.ndslice;
 /++
 Bitmapデータを表すstructです．
 画素を表すPixelの集合で構成されます．
@@ -166,7 +166,7 @@ struct Bitmap(T){
         }
         
         ///
-        Slice!(3LU, V*) sliced(V = float)(){
+        Slice!(Canonical, [3LU], V*) sliced(V = float)(){
             import std.range;
             import std.algorithm;
             import std.conv;
@@ -184,7 +184,7 @@ struct Bitmap(T){
                     }
                 }
             }
-            return data.sliced(_size[0], _size[1], numElements);
+            return data.sliced(_size[0], _size[1], numElements).canonical;
         }
     }
 


### PR DESCRIPTION
replace std.experimental.ndslice to mir.ndslice.
std.experimental.ndslice was deprecated.